### PR TITLE
Allow forcing of host page protocol

### DIFF
--- a/code/IFramePage.php
+++ b/code/IFramePage.php
@@ -12,7 +12,8 @@ class IFramePage extends Page {
 		'FixedHeight' => 'Int(500)',
 		'FixedWidth' => 'Int(0)',
 		'AlternateContent' => 'HTMLText',
-		'BottomContent' => 'HTMLText'
+		'BottomContent' => 'HTMLText',
+		'ForceProtocol' => 'Varchar',
 	);
 
 	static $defaults = array(
@@ -30,6 +31,14 @@ class IFramePage extends Page {
 		$fields->removeFieldFromTab('Root.Main', 'Content');
 		$fields->addFieldToTab('Root.Main', $url = new TextField('IFrameURL', 'Iframe URL'), 'Metadata');
 		$url->setRightTitle('Can be absolute (<em>http://silverstripe.com</em>) or relative to this site (<em>about-us</em>).');
+		$fields->addFieldToTab(
+			'Root.Main',
+			DropdownField::create('ForceProtocol', 'Force protocol?')
+				->setSource(array('http://' => 'http://', 'https://' => 'https://'))
+				->setEmptyString('')
+				->setDescription('Avoids mixed content warnings when iframe content is just available under a specific protocol'),
+			'Metadata'
+		);
 		$fields->addFieldToTab('Root.Main', new CheckboxField('AutoHeight', 'Auto height (only works with same domain URLs)'), 'Metadata');
 		$fields->addFieldToTab('Root.Main', new CheckboxField('AutoWidth', 'Auto width (100% of the available space)'), 'Metadata');
 		$fields->addFieldToTab('Root.Main', new NumericField('FixedHeight', 'Fixed height (in pixels)'), 'Metadata');
@@ -78,6 +87,14 @@ class IFramePage extends Page {
 class IFramePage_Controller extends Page_Controller {
 	function init() {
 		parent::init();
+
+		if($this->ForceProtocol) {
+			if($this->ForceProtocol == 'http://' && Director::protocol() != 'http://') {
+				return $this->redirect(preg_replace('#https://#', 'http://', $this->AbsoluteLink()));
+			} else if($this->ForceProtocol == 'https://' && Director::protocol() != 'https://') {
+				return $this->redirect(preg_replace('#http://#', 'https://', $this->AbsoluteLink()));
+			}
+		}
 
 		if ($this->IFrameURL) {
 			Requirements::javascript('iframe/javascript/iframe_page.js');

--- a/tests/IFramePageTest.php
+++ b/tests/IFramePageTest.php
@@ -33,4 +33,49 @@ class IFramePageTest extends SapphireTest {
 		$iframe->FixedWidth = '200';
 		$this->assertContains('width: 200px', $iframe->getStyle(), 'Fixed width is settable');
 	}
+
+	public function testForceProtocol() {
+		$origServer = $_SERVER;
+
+		$page = new IFramePage();
+		$page->URLSegment = 'iframe';
+		$page->IFrameURL = 'http://target.com';
+
+		Config::inst()->update('Director', 'alternate_protocol', 'http');
+		Config::inst()->update('Director', 'alternate_base_url', 'http://host.com');
+		$page->ForceProtocol = '';
+		$controller = new IFramePage_Controller($page);
+		$response = $controller->init();
+		$this->assertNull($response);
+
+		Config::inst()->update('Director', 'alternate_protocol', 'https');
+		Config::inst()->update('Director', 'alternate_base_url', 'https://host.com');
+		$page->ForceProtocol = '';
+		$controller = new IFramePage_Controller($page);
+		$response = $controller->init();
+		$this->assertNull($response);
+
+		Config::inst()->update('Director', 'alternate_protocol', 'http');
+		Config::inst()->update('Director', 'alternate_base_url', 'http://host.com');
+		$page->ForceProtocol = 'http://';
+		$controller = new IFramePage_Controller($page);
+		$response = $controller->init();
+		$this->assertNull($response);
+
+		Config::inst()->update('Director', 'alternate_protocol', 'http');
+		Config::inst()->update('Director', 'alternate_base_url', 'http://host.com');
+		$page->ForceProtocol = 'https://';
+		$controller = new IFramePage_Controller($page);
+		$response = $controller->init();
+		$this->assertEquals($response->getHeader('Location'), 'https://host.com/iframe/');
+
+		Config::inst()->update('Director', 'alternate_protocol', 'https');
+		Config::inst()->update('Director', 'alternate_base_url', 'https://host.com');
+		$page->ForceProtocol = 'http://';
+		$controller = new IFramePage_Controller($page);
+		$response = $controller->init();
+		$this->assertEquals($response->getHeader('Location'), 'http://host.com/iframe/');
+
+		$_SERVER = $origServer;
+	}
 }


### PR DESCRIPTION
Avoid mixed content issues when host page is https://
but iframe URL is specified as http://.
