### PR TITLE
FIX Add table_name to IFramePage

### DIFF
--- a/src/IFramePage.php
+++ b/src/IFramePage.php
@@ -33,6 +33,8 @@ class IFramePage extends Page
         'FixedWidth' => '0'
     );
 
+    private static $table_name = 'IFramePage';
+
     private static $description = 'Embeds an iframe into the body of the page.';
 
     private static $singular_name = 'IFrame Page';


### PR DESCRIPTION
This now triggers a user warning (see https://github.com/silverstripe/silverstripe-framework/issues/6904), which breaks any unit tests.

It should also be in place for SS3 to SS4 upgrading to minimise data migration.