### PR TITLE
FIX Add CMS configurable title for iframe to tell screenreaders it contains frame content

### DIFF
--- a/src/IFramePage.php
+++ b/src/IFramePage.php
@@ -8,6 +8,8 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\HTMLEditor\HtmlEditorField;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\ORM\ValidationResult;
 
 /**
  * Iframe page type embeds an iframe of URL of choice into the page.
@@ -18,6 +20,7 @@ class IFramePage extends Page
 {
     private static $db = array(
         'IFrameURL' => 'Text',
+        'IFrameTitle' => 'Varchar',
         'AutoHeight' => 'Boolean(1)',
         'AutoWidth' => 'Boolean(1)',
         'FixedHeight' => 'Int(500)',
@@ -45,7 +48,11 @@ class IFramePage extends Page
         $fields = parent::getCMSFields();
 
         $fields->removeFieldFromTab('Root.Main', 'Content');
-        $fields->addFieldToTab('Root.Main', $url = new TextField('IFrameURL', 'Iframe URL'));
+        $fields->addFieldsToTab('Root.Main', [
+            $url = TextField::create('IFrameURL', 'Iframe URL'),
+            TextField::create('IFrameTitle', 'Iframe Title')
+                ->setDescription(_t(__CLASS__ . '.TITLE_DESCRIPTION', 'Used to identify the contents of the Iframe')),
+        ]);
         $url->setRightTitle(
             DBField::create_field(
                 'HTMLText',

--- a/src/IFramePage.php
+++ b/src/IFramePage.php
@@ -50,8 +50,8 @@ class IFramePage extends Page
         $fields->removeFieldFromTab('Root.Main', 'Content');
         $fields->addFieldsToTab('Root.Main', [
             $url = TextField::create('IFrameURL', 'Iframe URL'),
-            TextField::create('IFrameTitle', 'Iframe Title')
-                ->setDescription(_t(__CLASS__ . '.TITLE_DESCRIPTION', 'Used to identify the contents of the Iframe')),
+            TextField::create('IFrameTitle', 'Description of contents (title)')
+                ->setDescription(_t(__CLASS__ . '.TITLE_DESCRIPTION', 'Used by screen readers')),
         ]);
         $url->setRightTitle(
             DBField::create_field(

--- a/templates/SilverStripe/IFrame/Layout/IFramePage.ss
+++ b/templates/SilverStripe/IFrame/Layout/IFramePage.ss
@@ -9,7 +9,7 @@
 		<div class="nonvisual-indicator" style="position: absolute; overflow: hidden; clip: rect(0 0 0 0); height: 1px; width: 1px; margin: -1px; padding: 0; border: 0;">
 			<%t SilverStripe\\IFrame\\IFramePage.ExternalNote "Please note the following section of content is possibly being delivered from an external source (IFRAME in HTML terms), and may present unusual experiences for screen readers." %>
 		</div>
-		<iframe id="Iframepage-iframe" style="$Style" src="$IFrameURL" class="$Class">$AlternateContent</iframe>
+		<iframe id="Iframepage-iframe" style="$Style" src="$IFrameURL" class="$Class" title="$IFrameTitle">$AlternateContent</iframe>
 	<% end_if %>
 	$BottomContent
 </div>


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-iframe/issues/43